### PR TITLE
[250719] PGS 네트워크

### DIFF
--- a/src/athena/week2/athena_programmer_network.kt
+++ b/src/athena/week2/athena_programmer_network.kt
@@ -1,0 +1,35 @@
+package athena.week2
+
+import javax.xml.stream.events.StartElement
+
+fun main() {
+    println(Solution().solution(3, arrayOf(intArrayOf(1, 1, 0), intArrayOf(1, 1, 0), intArrayOf(0, 0, 1))))
+}
+
+class Solution {
+    fun solution(n: Int, computers: Array<IntArray>): Int {
+        var answer = 0
+
+        val visited = BooleanArray(n) { false }
+
+        for (start in 0 until n) {
+            if (visited[start].not()) {
+                answer += 1
+                dfs(n, start, visited, computers)
+            }
+        }
+        return answer
+    }
+
+    fun dfs(n: Int, start: Int, visited: BooleanArray, computers: Array<IntArray>) {
+        visited[start] = true
+
+        for (end in 0 until n) {
+            if (computers[start][end] == 1 && visited[end].not()) {
+                dfs(n, end, visited, computers)
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
## 문제 해결 과정
- `BooleanArray` 만들어서 방문 여부 확인, 방문이 안 되어있다면 `answer += 1 `
- `dfs`함수는 n번째 컴퓨터와 연결된 `Array<IntArray>`를 훑으면서 `computers[start][end]`에 1이 있는지 확인하다.
   - 1이 있고, 방문한적이 없으면 다시 `dfs`를 돌린후 `visited[true]`를 만들어준다. 
   - 다시 `dfs`함수로 end번째 있는 computer를 순회하러간다.

## 시간복잡도
- O(n^2)
  - 방문이 안되어있으면 `dfs`함수를 호출한다. 
      ```
      for (start in 0 until n) {
          if (!visited[start]) {
              dfs(...)
          }
      }
      ```
  - 그러나 `dfs`함수 내부의 for문은 start와 연결된 end를 찾기위해 n번 돌아야한다.
      ```
      for (end in 0 until n) {
                  if (computers[start][end] == 1 && visited[end].not()) {
                      dfs(n, end, visited, computers)
                  }
              }
      ```
  - `visited`를 체크해서 돌기때문에 실행횟수가 줄어들 순 있지만 최악의 경우를 고려하면  O(n^2) 가 된다.

## 기타  
- 시간복잡도 판단 하는 부분에서 다른 방법이 있다면 리뷰 부탁드립니다. 
