### PR TITLE
[250727] PGS 단어변환

### DIFF
--- a/src/athena/week3/athena_programmer_wordchange.kt.kt
+++ b/src/athena/week3/athena_programmer_wordchange.kt.kt
@@ -1,0 +1,45 @@
+package athena.week3
+
+fun main() {
+    val solution = Solution()
+    println(solution.solution("hit", "cog", arrayOf("hot", "dot", "dog", "lot", "log")))
+}
+
+class Solution {
+    var answer = Int.MAX_VALUE
+
+    fun solution(begin: String, target: String, words: Array<String>): Int {
+        if (!words.contains(target)) {
+            return 0
+        } else {
+            val visited = BooleanArray(words.size)
+            dfs(begin, target, words, visited, 0)
+        }
+        return if (answer == Int.MAX_VALUE) 0 else answer
+    }
+
+    fun dfs(begin: String, target: String, words: Array<String>, visited: BooleanArray, depth: Int) {
+        if (begin == target) {
+            answer = minOf(answer, depth)
+            return
+        }
+
+        for (i in words.indices) {
+            if (!visited[i] && checkLetter(begin, words[i])) {
+                visited[i] = true
+                dfs(words[i], target, words, visited, depth + 1)
+                visited[i] = false
+            }
+        }
+    }
+
+    private fun checkLetter(begin: String, word: String): Boolean {
+        var count = 0
+        for (i in begin.indices) {
+            if (begin[i] != word[i]) count++
+            if (count > 1) return false
+        }
+        return count == 1
+    }
+}
+


### PR DESCRIPTION
## 문제 조건
- 1회 1단어로만 교체 가능 (조건: 알파벳 1글자 변경 가능)
	1. hot -> hit 가능 , hot -> dog 2글자 이상 변경 불가
	2. `begin[n]`중에서 알파벳 1개만 다른 단어 찾기
- `words`에 `target`이 없으면 `answer`는 0이다.

## DFS을 이용한 문제 해결 과정
- DFS 함수로 가능한 모든 변환 경로 탐색
- 방문 여부를 `visited`로 체크

## 개선
- 최단 거리 탐색 문제이기 때문에 BFS로 문제를 푸는게 더 효율적이었던거 같습니다. BFS로도 문제를 풀고 비교해보도록 하겠습니다. 