### PR TITLE
[250730] PGS 여행경로

### DIFF
--- a/src/athena/week3/athena_programmer_wordchange.kt.kt
+++ b/src/athena/week3/athena_programmer_wordchange.kt.kt
@@ -1,0 +1,45 @@
+package athena.week3
+
+fun main() {
+    val solution = Solution()
+    println(solution.solution("hit", "cog", arrayOf("hot", "dot", "dog", "lot", "log")))
+}
+
+class Solution {
+    var answer = Int.MAX_VALUE
+
+    fun solution(begin: String, target: String, words: Array<String>): Int {
+        if (!words.contains(target)) {
+            return 0
+        } else {
+            val visited = BooleanArray(words.size)
+            dfs(begin, target, words, visited, 0)
+        }
+        return if (answer == Int.MAX_VALUE) 0 else answer
+    }
+
+    fun dfs(begin: String, target: String, words: Array<String>, visited: BooleanArray, depth: Int) {
+        if (begin == target) {
+            answer = minOf(answer, depth)
+            return
+        }
+
+        for (i in words.indices) {
+            if (!visited[i] && checkLetter(begin, words[i])) {
+                visited[i] = true
+                dfs(words[i], target, words, visited, depth + 1)
+                visited[i] = false
+            }
+        }
+    }
+
+    private fun checkLetter(begin: String, word: String): Boolean {
+        var count = 0
+        for (i in begin.indices) {
+            if (begin[i] != word[i]) count++
+            if (count > 1) return false
+        }
+        return count == 1
+    }
+}
+

--- a/src/athena/week4/athena_programmer_travelroute.kt
+++ b/src/athena/week4/athena_programmer_travelroute.kt
@@ -1,0 +1,43 @@
+package athena.week4
+
+fun main() {
+    val solution = Solution()
+    println(
+        solution.solution(arrayOf(arrayOf("ICN", "JFK"), arrayOf("HND", "IAD"), arrayOf("JFK", "HND")))
+            .joinToString { it })
+}
+
+class Solution {
+    fun solution(tickets: Array<Array<String>>): Array<String> {
+        val visited = BooleanArray(tickets.size)
+        var bestPath: Array<String>? = null
+
+        val sortedTickets = tickets.sortedWith(compareBy({ it[0] }, { it[1] }))
+
+        fun dfs(current: String, path: MutableList<String>) {
+            if (path.size == tickets.size + 1) {
+                val newPath = path.toTypedArray()
+                if (bestPath == null || newPath.contentToString() < bestPath!!.contentToString()) {
+                    bestPath = newPath
+                }
+                return
+            }
+
+            for (i in sortedTickets.indices) {
+                if (!visited[i] && sortedTickets[i][0] == current) {
+                    visited[i] = true
+                    path.add(sortedTickets[i][1])
+
+                    dfs(sortedTickets[i][1], path)
+
+                    visited[i] = false
+                    path.removeLast()
+                }
+            }
+        }
+        val startPath = mutableListOf("ICN")
+        dfs("ICN", startPath)
+
+        return bestPath!!
+    }
+}


### PR DESCRIPTION
## 문제 해결 과정
- DFS + 백트래킹
  - 한 방향으로만 진행한다면 모든 티켓을 체크할 수 없는 경우가 발생하므로 백트래킹을 통해 되돌아가게끔 만들어야한다. 
  - 알파벳 순서대로 경로를 짜야하므로 미리 사전순으로 정렬한다. 
  - `sortedWith`는 `tickets`를 제자리 정렬하지않으므로 변수를 따로 만들어서 대입한다.
## BFS 풀이 실패
  - 모든 티켓을 정확히 한 번씩 사용해야하고, 큐에 넣는 순서에 따라 결과가 달라진다. 
  - BFS는 최단 거리에 적합하고, 모든 경로를 비교하는 조건은 DFS로 푸는 것이 적절하다.

