### PR TITLE
[250810] PGS 퍼즐 조각 채우기

### DIFF
--- a/src/athena/week5/athena_boj_1926.kt
+++ b/src/athena/week5/athena_boj_1926.kt
@@ -1,0 +1,51 @@
+package athena.week5
+
+import java.util.LinkedList
+import java.util.Queue
+
+fun main() {
+    val (n, m) = readln().split(" ").map { it.toInt() }
+    val picture = Array(n) { readln().split(" ").map { it.toInt() }.toIntArray() }
+    val visited = Array(n) { IntArray(m) }
+
+    //(상, 하, 좌, 우)
+    val dx = intArrayOf(0, 0, +1, -1)
+    val dy = intArrayOf(+1, -1, 0, 0)
+
+    var count = 0
+    var maxArea = 0
+
+    val queue: Queue<Pair<Int, Int>> = LinkedList()
+
+    for (i in 0..<n) {
+        for (j in 0..<m) {
+            if (picture[i][j] == 1 && visited[i][j] == 0) {
+                count++
+                var area = 0
+                queue.clear()
+                queue.add(i to j)
+                visited[i][j] = 1
+
+                while (queue.isNotEmpty()) {
+                    val (x, y) = queue.poll()
+                    area++
+
+                    for (k in 0..<4) {
+                        val nx = x + dx[k]
+                        val ny = y + dy[k]
+
+                        if (nx !in 0 until n || ny !in 0 until m) continue
+
+                        if (picture[nx][ny] == 1 && visited[nx][ny] == 0) {
+                            visited[nx][ny] = 1
+                            queue.add(nx to ny)
+                        }
+                    }
+                }
+                if (area > maxArea) maxArea = area
+            }
+        }
+    }
+    println(count)
+    println(maxArea)
+}

--- a/src/athena/week5/athena_boj_2178.kt
+++ b/src/athena/week5/athena_boj_2178.kt
@@ -1,0 +1,33 @@
+package athena.week5
+
+import java.util.*
+
+fun main() {
+    val (n, m) = readln().split(" ").map { it.toInt() }
+    val arrays = Array(n) { readln().map { it.digitToInt() }.toIntArray() }
+    val visited = Array(n) { IntArray(m) }
+
+    //(상, 하, 좌, 우)
+    val dx = intArrayOf(-1, 1, 0, 0)
+    val dy = intArrayOf(0, 0, -1, 1)
+
+    val queue: Queue<Pair<Int, Int>> = LinkedList()
+    queue.add(0 to 0)
+    visited[0][0] = 1
+
+    while (queue.isNotEmpty()) {
+        val (x, y) = queue.poll()
+        for (i in 0 until 4) {
+            val nx = x + dx[i]
+            val ny = y + dy[i]
+
+            if (nx !in 0 until n || ny !in 0 until m) continue
+
+            if (arrays[nx][ny] == 1 && visited[nx][ny] == 0) {
+                visited[nx][ny] = visited[x][y] + 1
+                queue.add(nx to ny)
+            }
+        }
+    }
+    println(visited[n - 1][m - 1])
+}

--- a/src/athena/week5/athena_programmer_puzzle.kt
+++ b/src/athena/week5/athena_programmer_puzzle.kt
@@ -1,0 +1,8 @@
+package athena.week5
+
+class Solution {
+    fun solution(game_board: Array<IntArray>, table: Array<IntArray>): Int {
+        var answer: Int = -1
+        return answer
+    }
+}


### PR DESCRIPTION
# 1. 퍼즐 조각 채우기
## 문제 설명
- 여러개의 퍼즐 조각이 있다. 게임보드에 껴 맞춘다고 할 때 총 몇 칸을 채울 수 있는가?
- 조건
  - 조각은 한 번에 하나씩 채워 넣습니다.
  - 조각을 회전시킬 수 있습니다. 
  - 조각을 뒤집을 수는 없습니다.
  - 게임 보드에 새로 채워 넣은 퍼즐 조각과 인접한 칸이 비어있으면 안 됩니다.

## 풀이 시도 – 구현 중단
- 시도
  - `bfs`로 그림의 사이즈를 확인하여 그 크기가 일치하고, 시작점이 같으면 answer에 더한다.
  - 조각 회전 시 모양 비교 로직을 어떻게 구현할지 구체적인 아이디어가 떠오르지 않아 중단.
- 우선 백준 1926 그림, 2178 미로탐색 등 BFS 기초 문제로 로직 숙련했습니다.
  - https://www.acmicpc.net/problem/2178
  - https://www.acmicpc.net/problem/1926


# 2. 그림
## 문제 해결 과정
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/60b93d65-88d6-48a7-b1cb-f38375e619bb" />

- dx, dy로 상하좌우 돌아다니면서 1을 찾는다. (대각선 연결 포함 X.)
- `visited`를 이용하여 순회한 곳은 제외하고 돌아다닌다. 


# 3. 미로 찾기
## 문제 해결 과정
- dx, dy로 상하좌우 돌아다니면서 1을 찾는다. (대각선 연결 포함 X.)
- `visited`를 이용하여 순회한 곳은 제외하고 돌아다닌다. 
- 최대 크기만 필요하므로 `bfs`함수 내부에 `area` 변수를 만들어서 계산 후 `maxArea`로 반환한다.

